### PR TITLE
Changing datatype and adding a int cast

### DIFF
--- a/level02/union.c
+++ b/level02/union.c
@@ -15,14 +15,14 @@
 void	ft_union(char *str1, char *str2)
 {
 	int		i;
-	char	str_union[4096];
+	int     str_union[4096];
 
 	i = 0;
 	while (str1[i])
 	{
-		if (!str_union[str1[i]])
+		if (!str_union[(int)str1[i]])
 		{
-			str_union[str1[i]] = 1;
+			str_union[(int)str1[i]] = 1;
 			write (1, &str1[i], 1);
 		}
 		i += 1;
@@ -30,9 +30,9 @@ void	ft_union(char *str1, char *str2)
 	i = 0;
 	while (str2[i])
 	{
-		if (!str_union[str2[i]])
+		if (!str_union[(int)str2[i]])
 		{
-			str_union[str2[i]] = 1;
+			str_union[(int)str2[i]] = 1;
 			write (1, &str2[i], 1);
 		}
 		i += 1;


### PR DESCRIPTION
Pretty close with the right logic in mind. However, your `char str_union[4096]` wasn't properly making a new string with the strings found. To fix this, you must cast your str_union to take the index value of str1[i] and str[2]. Let me know if anything comes up.