### PR TITLE
ft_list_size.c bug + more readable structure

### DIFF
--- a/level03/ft_list_size.c
+++ b/level03/ft_list_size.c
@@ -15,17 +15,12 @@
 int		ft_list_size(t_list *begin_list)
 {
 	int		size;
-	t_list	*list;
-
-	size = 0;
-	list = begin_list;
-	if (list)
-	{
-		while (!(list->next))
-		{
-			list = list->next;
-			size += 1;
-		}
-	}
-	return (size - 1);
+	
+    size = 0;
+    while (begin_list)
+    {
+        begin_list = begin_list->next;
+        size += 1;
+    }
+	return (size);
 }


### PR DESCRIPTION
I was just looking at your usage in ft_list_size function and it seems to _segfault_. The loop was accessing beyond the limit at the end, which caused to not read the proper size of the LL when you specified `!(list->next)`. Have a nice day :)