### PR TITLE
Update in ft_strrev.c due to bug

### DIFF
--- a/level02/ft_strrev.c
+++ b/level02/ft_strrev.c
@@ -26,6 +26,5 @@ char		*ft_strrev(char *str)
 		str[i] = str[len];
 		str[len] = tmp;
 	}
-	str[i] = '\0';
 	return (str);
 }


### PR DESCRIPTION
Removed `str[i] = '\0'` because was not properly strrev.