### PR TITLE
flg variable need to initiliaze to zero

### DIFF
--- a/level03/epur_str.c
+++ b/level03/epur_str.c
@@ -17,7 +17,8 @@ int		main(int argc, char const *argv[])
 	int		i;
 	int		flg;
 
-	if (argc == 2)
+	flg = 0;
+    if (argc == 2)
 	{
 		i = 0;
 		while (argv[1][i] == ' ' || argv[1][i] == '\t')

--- a/level03/expand_str.c
+++ b/level03/expand_str.c
@@ -17,7 +17,8 @@ int		main(int argc, char const *argv[])
 	int		i;
 	int		flg;
 
-	if (argc == 2)
+	flg = 0;
+    if (argc == 2)
 	{
 		i = 0;
 		while (argv[1][i] == ' ' || argv[1][i] == '\t')

--- a/level03/ft_atoi_base.c
+++ b/level03/ft_atoi_base.c
@@ -37,9 +37,9 @@ int		ft_atoi_base(const char *str, int base)
 			sign *= -1;
 	while (str[i] && nbr_inbase(str[i], base))
 	{
-		if (str[i] >= 'A' && 'F' >= str[i])
+		if (str[i] >= 'A' && str[i] <= 'F)
 			nbr = (nbr * base) + (str[i] - 'A' + 10);
-		else if (str[i] >= 'a' && 'f' >= str[i])
+		else if (str[i] >= 'a' && str[i] <= 'f')
 			nbr = (nbr * base) + (str[i] - 'a' + 10);
 		else
 			nbr = (nbr * base) + (str[i] - '0');

--- a/level03/ft_atoi_base.c
+++ b/level03/ft_atoi_base.c
@@ -26,7 +26,8 @@ int		ft_atoi_base(const char *str, int base)
 
 	if (!str[0] || (base < 2 || base > 16))
 		return (0);
-	nbr = 0;
+	i = 0;
+    nbr = 0;
 	sign = 1;
 	while (str[i] == '\t' || str[i] == '\v' || str[i] == '\n' || \
 		str[i] == ' ' || str[i] == '\r' || str[i] == '\f')


### PR DESCRIPTION
This pull request includes small changes to initialize the `flg` variable in two different files. The changes ensure that `flg` is set to 0 at the start of the `main` function in both `level03/epur_str.c` and `level03/expand_str.c`.

Initialization of `flg` variable:

* [`level03/epur_str.c`](diffhunk://#diff-a7ab7fece8464b3b74d4897e05b1db13e42ab9314d264a7874de89207a5d4f2cR20): Added initialization of `flg` to 0 in the `main` function.
* [`level03/expand_str.c`](diffhunk://#diff-fdf29eac8e941ccbd3e1d0de6cca3e015492eb70cca9f28ad91fa405d41a6db5R20): Added initialization of `flg` to 0 in the `main` function.